### PR TITLE
Merge from Develop

### DIFF
--- a/HKPreloaders.podspec
+++ b/HKPreloaders.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'HKPreloaders'
-  s.version          = '0.1.3'
+  s.version          = '0.1.4'
   s.summary          = 'A set of preloader animations written in Swift.'
   
   s.description      = <<-DESC

--- a/HKPreloaders/Classes/HKMorphingPreloaderView.swift
+++ b/HKPreloaders/Classes/HKMorphingPreloaderView.swift
@@ -50,7 +50,7 @@ public class HKMorphingPreloaderView: UIView{
     }
     
     private func loadViewFromNib() -> UIView{
-        let bundle = ResourceLoader.getBundle(forClass: HKMorphingPreloaderView.self)
+        let bundle = ResourceLoader.getBundleForNibs(forClass: HKMorphingPreloaderView.self)
         let nib = UINib(nibName: "HKMorphingPreloaderView", bundle: bundle)
         let loadedView = nib.instantiate(withOwner: self, options: nil).first as! UIView
         return loadedView

--- a/HKPreloaders/Classes/HKPreloaderCommons.swift
+++ b/HKPreloaders/Classes/HKPreloaderCommons.swift
@@ -10,10 +10,29 @@ import UIKit
 import Foundation
 
 internal class ResourceLoader{
-    static func getBundle(forClass: AnyClass) -> Bundle{
+    
+    /**
+     Safely gets the correct bundle where
+     nibs are stored at.
+     
+     This class was implemented because I couldn't get this pod
+     to properly instantiate the UINib(s) when the pod's environment
+     changes between development and production-use.
+     
+     The solution: If we find the nested-bundle 'HKPreloaders' (generated
+     by the podspec, as the Resource Bundle) return it. This means the pod
+     is in a production-use environment. Otherwise, return the podBundle itself.
+     
+     - parameters:
+        - forClass: The class used to search for the top-level bundle
+     */
+    
+    static func getBundleForNibs(forClass: AnyClass) -> Bundle{
         let podBundle = Bundle(for: forClass)
-        let path = podBundle.path(forResource: "HKPreloaders", ofType: "bundle")! // The resource bundle
-        return Bundle(path: path)!
+        if let path = podBundle.path(forResource: "HKPreloaders", ofType: "bundle"){
+            return Bundle(path: path)!  // The resource bundle
+        }
+        return podBundle
     }
 }
 

--- a/HKPreloaders/Classes/HKSpinningPreloaderView.swift
+++ b/HKPreloaders/Classes/HKSpinningPreloaderView.swift
@@ -55,7 +55,7 @@ public class HKSpinningPreloaderView: UIView{
     }
     
     private func loadViewFromNib() -> UIView{
-        let bundle = ResourceLoader.getBundle(forClass: HKSpinningPreloaderView.self)
+        let bundle = ResourceLoader.getBundleForNibs(forClass: HKSpinningPreloaderView.self)
         let nib = UINib(nibName: "HKSpinningPreloaderView", bundle: bundle)
         let loadedView = nib.instantiate(withOwner: self, options: nil).first as! UIView
         return loadedView


### PR DESCRIPTION
Fixed the issues with two different nib loading methods being required when developing and deploying the pod.

The fix was to modify the `getBundleForNibs()` method in the `ResourceLoader` class.

```
static func getBundleForNibs(forClass: AnyClass) -> Bundle{
        let podBundle = Bundle(for: forClass)
        if let path = podBundle.path(forResource: "HKPreloaders", ofType: "bundle"){
            return Bundle(path: path)!  // The resource bundle
        }
        return podBundle
}
```

TL:DR; We use the pod bundle to load assets if in development environment and the nested __resource bundle__ if we're in the production-use environment.